### PR TITLE
bugfix: Use default import for `@next/eslint-plugin-next`

### DIFF
--- a/.changeset/rich-rings-fly.md
+++ b/.changeset/rich-rings-fly.md
@@ -1,0 +1,5 @@
+---
+"@praha/eslint-config-next": patch
+---
+
+Use default import for `@next/eslint-plugin-next`

--- a/packages/next/src/configurators/next-configurator.ts
+++ b/packages/next/src/configurators/next-configurator.ts
@@ -6,6 +6,7 @@ import type { ESLint, Linter } from 'eslint';
 export const nextConfigurator: Configurator = () => {
   return [
     {
+      name: 'next/core-web-vitals',
       plugins: {
         '@next/next': pluginNext as ESLint.Plugin,
       },

--- a/packages/next/src/configurators/next-configurator.ts
+++ b/packages/next/src/configurators/next-configurator.ts
@@ -1,10 +1,17 @@
-import { flatConfig as eslintPluginNextConfigs } from '@next/eslint-plugin-next';
+import pluginNext from '@next/eslint-plugin-next';
 
 import type { Configurator } from '@praha/eslint-config-definer';
-import type { Linter } from 'eslint';
+import type { ESLint, Linter } from 'eslint';
 
 export const nextConfigurator: Configurator = () => {
   return [
-    eslintPluginNextConfigs.coreWebVitals as Linter.Config,
+    {
+      plugins: {
+        '@next/next': pluginNext as ESLint.Plugin,
+      },
+      rules: {
+        ...pluginNext.configs['core-web-vitals'].rules as Linter.Config['rules'],
+      },
+    },
   ];
 };

--- a/packages/style/src/configurators/stylistic.ts
+++ b/packages/style/src/configurators/stylistic.ts
@@ -6,7 +6,6 @@ export const stylistic: Configurator = () => {
   return [
     {
       name: 'stylistic/recommended',
-
       ...eslintPluginStylistic.configs.customize({
         indent: 2,
         quotes: 'single',

--- a/packages/style/src/configurators/stylistic.ts
+++ b/packages/style/src/configurators/stylistic.ts
@@ -6,7 +6,7 @@ export const stylistic: Configurator = () => {
   return [
     {
       name: 'stylistic/recommended',
-      // eslint-disable-next-line import-x/no-named-as-default-member
+
       ...eslintPluginStylistic.configs.customize({
         indent: 2,
         quotes: 'single',


### PR DESCRIPTION
## 概要

4.0.7で`'@next/eslint-plugin-next'`を名前付きインポートするようにしたことによりエラーが発生するようになったため、デフォルトインポートするように修正。

```
Oops! Something went wrong! :(

ESLint: 9.32.0

file:///Users/kondoushun/environment/shitsumonbako/node_modules/@praha/eslint-config-next/dist/esm/configurators/next-configurator.js:1
import { flatConfig } from "@next/eslint-plugin-next";
         ^^^^^^^^^^
SyntaxError: Named export 'flatConfig' not found. The requested module '@next/eslint-plugin-next' is a CommonJS module, which may not support all module.exports as named exports.
```

またexportしているConfiguratorがFlat Configに対応した形式になっておらずエラーが発生したため、Flat Configに対応した形式に修正。

```
Oops! Something went wrong! :(

ESLint: 9.32.0

A config object has a "plugins" key defined as an array of strings. It looks something like this:
    {
        "plugins": ["@next/next"]
    }
Flat config requires "plugins" to be an object, like this:
    {
        plugins: {
            @next/next: pluginObject
        }
    }
```

## 動作確認

ローカルでインストールしてeslint-plugin-nextのルールが効いてそうなことを確認。
<img width="1946" height="454" alt="CleanShot 2025-08-05 at 18 09 03@2x" src="https://github.com/user-attachments/assets/3cdb8161-814d-417d-afa4-894baf02cbf5" />
